### PR TITLE
Update XMLDeserializer.php

### DIFF
--- a/Spore/ReST/Data/Deserializer/XMLDeserializer.php
+++ b/Spore/ReST/Data/Deserializer/XMLDeserializer.php
@@ -70,7 +70,7 @@ class XMLDeserializer extends Base
     private static function elementToObject($element)
     {
         if (is_scalar($element)) {
-            return is_numeric((string) $element) ? (int) $element : (string) $element;
+            return (string) $element;
         } else {
             if (is_a($element, "SimpleXMLElement")) {
                 return self::xmlToObject($element);


### PR DESCRIPTION
You should not cast to a number here. I have XML that has a productnumber <productid>00012332</productid>. Casting to an int means the leading zeros get chopped. I also think is_numeric will be true, if the node's content is some decimal (123.345) and you cast that to an int - that will give you 123. Maybe the same problem applies to json-deserializer?
