### PR TITLE
Avoid empty stdClass instance for empty XML node

### DIFF
--- a/Spore/ReST/Data/Deserializer/XMLDeserializer.php
+++ b/Spore/ReST/Data/Deserializer/XMLDeserializer.php
@@ -69,7 +69,7 @@ class XMLDeserializer extends Base
 
     private static function elementToObject($element)
     {
-        if (is_scalar($element)) {
+        if (empty($element) || is_scalar($element)) {
             return (string) $element;
         } else {
             if (is_a($element, "SimpleXMLElement")) {


### PR DESCRIPTION
I think you should add this, too. This will avoid creating an empty stdClass instance for an empty node.
